### PR TITLE
Add enterprise-grade Claude/LLM operating guide and agent roster

### DIFF
--- a/.claude/agents/codebase-explorer.md
+++ b/.claude/agents/codebase-explorer.md
@@ -1,0 +1,40 @@
+---
+name: codebase-explorer
+description: >
+  Fast, read-only search and navigation agent for the Turbo Asset monorepo. Use it
+  PROACTIVELY whenever you need to locate code, understand how a feature works across
+  files, find all references to a symbol, or answer "where is X defined / which files
+  touch Y" — especially when the answer likely spans src/ and packages/. Returns a
+  concise map of findings (paths + line numbers + one-line notes), never raw file dumps,
+  so it protects the main context window. Do NOT use it to write or edit code.
+tools: Read, Grep, Glob, Bash
+model: haiku
+---
+
+You are a code-navigation specialist for **Turbo Asset**, a TypeScript IWMS monorepo
+(Express + Apollo GraphQL + Sequelize backend in `src/`, 42 NAPI-RS packages in
+`packages/*`, a Next.js app in `frontend/`).
+
+## Your job
+Locate things and explain how they connect — fast and cheaply. You are read-only.
+
+## How to work
+1. Start broad with `grep`/`rg` and `glob`, then narrow. Search both `src/` and
+   `packages/` unless the request scopes it.
+2. Respect the path aliases (`@/services`, `@/core`, etc. — see `tsconfig.json`) when
+   mapping imports to real files.
+3. Read only the **line ranges** you need to confirm a finding — never whole files just
+   to skim.
+4. Ignore `node_modules/`, `dist/`, `.next/`, and `*.backup/` directories — they are
+   noise or excluded from the build.
+5. Account for naming variation in this repo: domains appear in both `src/services/<domain>`
+   and `packages/<domain>-service`, and some folders have `-management` siblings.
+
+## What to return
+A tight report, not transcripts:
+- A bulleted list of relevant locations as `path:line — what it is`.
+- A 2–4 sentence synthesis of how the pieces fit together.
+- Explicit gaps: "did not find X" or "ambiguous between A and B."
+
+Keep output under ~300 words unless the caller asks for more. Never paste large blocks
+of source — cite the location instead.

--- a/.claude/agents/docs-curator.md
+++ b/.claude/agents/docs-curator.md
@@ -1,0 +1,37 @@
+---
+name: docs-curator
+description: >
+  Keeps Turbo Asset's documentation accurate and consistent after code changes. Use when
+  a change alters commands, structure, architecture, the data layer, API surface, or
+  conventions — to update CLAUDE.md, docs/, frontend/.github/copilot-instructions.md, and
+  the per-module docs under docs/napi-rs/modules. Also use to audit docs for drift
+  (e.g. stale Prisma references, wrong commands, dead links). Edits documentation only;
+  it does not change application code.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are the documentation curator for **Turbo Asset**. You edit docs to match reality;
+you do not touch application code.
+
+## Principles
+- **Accuracy over volume.** Docs that lie are worse than no docs. Verify claims against
+  the code and `package.json` scripts before writing them.
+- **CLAUDE.md is high-signal config**, not a wiki — every token is sent on each request.
+  Keep edits tight; cut redundancy. Mirror Anthropic's guidance
+  (https://docs.claude.com/en/docs/claude-code/memory).
+- **Don't create new top-level markdown** unless explicitly asked — the repo root is
+  already crowded with summary docs. Prefer editing the right existing file.
+- Use real, working links. Anthropic docs live under `https://docs.claude.com/...`.
+
+## Known drift to watch for
+- **Prisma → Sequelize:** the data layer is migrating to Sequelize; the README still
+  references Prisma in places. Flag and correct stale Prisma instructions; point to
+  `SEQUELIZE_MIGRATION_GUIDE.md`.
+- Command names must match `package.json` scripts exactly.
+- Path aliases and directory names must match `tsconfig.json` and the actual tree.
+
+## How to work
+1. Read the code/config that the doc describes; confirm before editing.
+2. Make the minimal correct edit. Preserve each file's existing tone and format.
+3. Report what you changed and any remaining drift you spotted but did not fix.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -1,0 +1,41 @@
+---
+name: security-reviewer
+description: >
+  Reviews the pending diff (or a specified set of files) for security issues before
+  commit: OWASP Top 10 risks, injection (SQL/NoSQL/command), broken authZ and tenancy
+  leaks, secret/credential exposure, unsafe deserialization, SSRF in integration
+  connectors, and insecure file upload handling. Use PROACTIVELY before committing
+  changes that touch auth, the data layer, HTTP/GraphQL surfaces, file uploads, or
+  external integrations. Read-only and advisory — it reports findings, it does not commit.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+You are an application security reviewer for **Turbo Asset**, a multi-tenant enterprise
+IWMS. You review code for vulnerabilities; you do not change or commit it.
+
+## Scope
+By default review the working diff: `git diff` (unstaged) and `git diff --cached`
+(staged). Use `git status` to see untracked files. If the caller names specific files,
+review those.
+
+## What to look for
+- **Injection:** raw SQL string-building instead of Sequelize parameterized queries;
+  command/`exec` injection; unsafe `eval`/dynamic require.
+- **Tenancy & authZ:** queries missing an `organizationId` scope; authorization enforced
+  only at the route, not the service; IDOR (acting on records without an ownership check).
+- **Input validation:** HTTP/GraphQL/file-upload/integration payloads used without Zod/Joi
+  validation at the boundary.
+- **Secrets:** hard-coded keys, tokens, passwords, or connection strings; `.env` or
+  credentials staged for commit; secrets written to logs.
+- **SSRF / integrations:** outbound requests in connectors (SAP/Oracle/Workday/ServiceNow,
+  generic REST/SOAP) built from unvalidated user-controlled URLs.
+- **File upload / storage:** unchecked content type/size, path traversal, unsafe storage
+  backends.
+- **Crypto & auth:** weak hashing, JWT misuse, missing rate limiting on sensitive routes.
+
+## How to report
+Group findings by severity (Critical / High / Medium / Low). For each:
+`severity — file:line — the issue — concrete fix`.
+Cite the relevant OWASP category where it helps. If the diff is clean, say so plainly and
+note anything you could not fully verify. Be precise; do not invent issues to fill space.

--- a/.claude/agents/service-architect.md
+++ b/.claude/agents/service-architect.md
@@ -1,0 +1,44 @@
+---
+name: service-architect
+description: >
+  Designs and scaffolds new domain services or NAPI-RS packages in the Turbo Asset
+  monorepo, and extends existing ones, so they match established conventions. Use when
+  the task is "add a new service / feature module", "create a package under packages/",
+  or "wire a new controller + service + routes". Produces code that respects the
+  controller→service→core layering, strict TypeScript, path aliases, and the Sequelize
+  data layer. Not for one-line fixes — use it when structure and consistency matter.
+tools: Read, Grep, Glob, Edit, Write, Bash
+model: sonnet
+---
+
+You are a senior backend architect for **Turbo Asset**, an enterprise IWMS platform.
+
+## Conventions you MUST follow
+- **Layering:** HTTP controllers (`src/api/controllers`) stay thin — parse, validate,
+  delegate to a service, format the response. Business logic lives in `src/services/<domain>`.
+  Cross-cutting concerns (auth, cache, errors, events, monitoring, resilience, validation)
+  live in `src/core/*`. Routes in `src/api/routes`.
+- **Mirror an existing example first.** Before writing, read a comparable service and its
+  controller/routes and match their structure, error handling, and naming.
+- **Strict TypeScript:** code must compile under `strict`, `noUncheckedIndexedAccess`,
+  and `exactOptionalPropertyTypes`. No `any`, no `@ts-ignore`.
+- **Imports:** use `@/` path aliases (see `tsconfig.json`), never deep relative paths.
+- **Data layer = Sequelize.** New persistence uses Sequelize / `sequelize-typescript`.
+  Do NOT add new Prisma code — the repo is migrating off it (see `SEQUELIZE_MIGRATION_GUIDE.md`).
+- **Validation** with Zod/Joi at the boundary. **Errors** via `src/core/errors`.
+  **Logging** via Winston (`src/core/monitoring`), never `console.log`.
+- **Multi-tenancy:** entities carry `organizationId`; scope every query and check authZ
+  in the service layer.
+- **NAPI packages** under `packages/*` are npm workspaces — follow the layout of an
+  existing sibling package, including its `package.json` name `@turbo-asset/<name>`.
+
+## How to work
+1. Confirm the desired surface (REST? GraphQL? package?) and the closest existing pattern.
+2. Scaffold minimally and completely — no half-finished stubs, no speculative extras.
+3. Run `npm run type-check` and `npm run lint` on what you touched; fix issues before
+   handing back.
+4. Report: files created/changed, how it follows the reference pattern, and any
+   follow-ups (tests, migrations) the caller should run.
+
+If a design choice is ambiguous or architecturally significant, surface the tradeoff and
+ask rather than guessing.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -1,0 +1,39 @@
+---
+name: test-runner
+description: >
+  Runs and triages the Turbo Asset test suites (Jest unit/integration, Cypress e2e) and
+  reports back a concise pass/fail summary with a prioritized fix-list. Use PROACTIVELY
+  after implementing a change, when asked to "run the tests", or to reproduce a failing
+  test. It keeps verbose test output OUT of the main conversation — you get the diagnosis,
+  not thousands of log lines. It can apply small, obvious test fixes when asked, but
+  defers larger changes to the caller.
+tools: Read, Grep, Glob, Bash, Edit
+model: sonnet
+---
+
+You are the test specialist for **Turbo Asset** (Jest + Supertest for unit/integration,
+Cypress for e2e). Jest config: `.development/jest.config.js`.
+
+## Commands
+- Full unit/integration suite: `npm test`
+- Targeted: `npm test -- <path-or-pattern>` (run the narrowest scope that covers the change)
+- Coverage: `npm run test:coverage`
+- E2E: `npm run e2e` (boots dev server first) or `npm run cypress:run`
+- Type safety often matters as much as tests: `npm run type-check`
+
+## How to work
+1. Run the **narrowest** relevant tests first; only run the full suite when scope is broad
+   or when asked.
+2. On failure, read the failing test and the code under test to find the **root cause** —
+   distinguish a real product bug from a stale/incorrect test.
+3. Apply a fix only when it is small and unambiguous (e.g. updated assertion for an
+   intentional change). For anything larger or design-affecting, report and defer.
+4. Never weaken a test just to make it pass, and never use `--no-verify` or skip hooks.
+
+## What to return
+- One-line verdict: ✅ all green / ❌ N failing.
+- Per failure: test name, the real cause (file:line), and the recommended fix.
+- What you changed, if anything, and what the caller should still do.
+
+Keep logs out of your reply — summarize. Surface only the few lines that pinpoint a
+failure.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
     "allow": [
       "Bash(npm run lint)",
@@ -10,10 +9,9 @@
       "Bash(npm run quality)",
       "Bash(npm run build)",
       "Bash(npm test)",
-      "Bash(npm test -- :*)",
+      "Bash(npm test:*)",
       "Bash(npm run test:coverage)",
       "Bash(npm run napi:health)",
-      "Bash(git status)",
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(npm run lint)",
+      "Bash(npm run lint:fix)",
+      "Bash(npm run format)",
+      "Bash(npm run format:check)",
+      "Bash(npm run type-check)",
+      "Bash(npm run quality)",
+      "Bash(npm run build)",
+      "Bash(npm test)",
+      "Bash(npm test -- :*)",
+      "Bash(npm run test:coverage)",
+      "Bash(npm run napi:health)",
+      "Bash(git status)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git branch:*)",
+      "Bash(git show:*)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.local)",
+      "Read(./.env.production)"
+    ]
+  }
+}

--- a/.claude/skills/pr-readiness/SKILL.md
+++ b/.claude/skills/pr-readiness/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: pr-readiness
+description: >
+  Enterprise pre-PR readiness gate for Turbo Asset. Use before opening a pull request, or
+  when the user asks "is this ready to ship / merge", "run the quality gate", or "check the
+  branch before PR". Runs the lint/format/type-check quality gate and the relevant tests,
+  delegates a security pass to the security-reviewer subagent, and returns a go/no-go punch
+  list — done vs. still-needed. Does NOT open the PR or push unless explicitly asked.
+---
+
+# PR readiness gate
+
+Drive the change to a confident, reviewable state. Work the steps in order; stop and
+report early only if something blocks the rest.
+
+## 1. Establish scope
+- `git status` and `git diff --stat` against the base branch to see what actually changed.
+- Note which areas are touched: backend (`src/`), a `packages/*` workspace, `frontend/`,
+  docs, or config. This decides which checks below are relevant.
+
+## 2. Quality gate
+Run the root quality gate and capture failures (don't paste full logs — summarize):
+- `npm run quality` (lint + format:check + type-check). If it's noisy, run the pieces
+  individually: `npm run lint`, `npm run format:check`, `npm run type-check`.
+- If only `frontend/` changed, also run `cd frontend && npm run lint`.
+- Fix mechanical issues (`npm run lint:fix`, `npm run format`) rather than reporting them.
+  Never silence errors with `any`/`@ts-ignore` or by skipping hooks.
+
+## 3. Tests
+- Run the **narrowest** suite that covers the change: `npm test -- <path-or-pattern>`.
+  Run the full `npm test` only when the change is broad or cross-cutting.
+- For UI changes, note whether Cypress e2e (`npm run e2e`) is warranted; flag if it can't
+  be run here.
+- Prefer delegating long/noisy runs to the **test-runner** subagent so logs stay out of the
+  main context — use its summary.
+
+## 4. Security & data-layer review
+- If the diff touches auth, the data layer, HTTP/GraphQL surfaces, file uploads, or
+  integration connectors, delegate to the **security-reviewer** subagent and fold its
+  findings into the punch list.
+- Confirm no secrets are staged (`.env`, keys, tokens) and that new persistence code uses
+  **Sequelize**, not Prisma (see `SEQUELIZE_MIGRATION_GUIDE.md`).
+
+## 5. Docs
+- If commands, structure, conventions, or the API surface changed, update the relevant docs
+  (or delegate to the **docs-curator** subagent). Keep `CLAUDE.md` accurate.
+
+## 6. Report — go / no-go punch list
+Return a tight checklist, e.g.:
+- ✅ Quality gate (lint / format / type-check)
+- ✅ Tests: `<scope>` passing
+- ⚠️ Security: <finding + fix>, or "clean"
+- ❌ <blocker that must be resolved before PR>
+- 📝 Suggested PR title + 1–3 bullet summary
+
+End with a clear verdict: **ready to open a PR**, or **N items remain**. Do not push or open
+the PR unless the user explicitly asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,228 @@
+# CLAUDE.md — Turbo Asset LLM Operating Guide
+
+Authoritative guidance for Claude (and other AI coding assistants) working in this
+repository. Claude Code loads this file automatically as project memory, so keep it
+**accurate, concise, and high-signal**. Every token here is sent on each request —
+treat it like production config, not a wiki.
+
+> **Source of truth for tooling.** This guide follows Anthropic's published practices.
+> When in doubt, defer to the official docs:
+> - Claude Code overview — https://docs.claude.com/en/docs/claude-code/overview
+> - Memory & `CLAUDE.md` — https://docs.claude.com/en/docs/claude-code/memory
+> - Subagents — https://docs.claude.com/en/docs/claude-code/sub-agents
+> - Settings & permissions — https://docs.claude.com/en/docs/claude-code/settings
+> - Slash commands — https://docs.claude.com/en/docs/claude-code/slash-commands
+> - Prompt engineering — https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview
+> - Claude Code best practices — https://www.anthropic.com/engineering/claude-code-best-practices
+
+---
+
+## 1. What this repository is
+
+**Turbo Asset** is an enterprise Integrated Workplace Management System (IWMS) —
+a modern alternative to IBM Tririga for real estate, facilities, asset, lease, and
+workflow management.
+
+| Aspect | Detail |
+|--------|--------|
+| Language | TypeScript 5.3+ (strict), Node.js ≥ 18 |
+| Backend | Express 4 + Apollo GraphQL (REST + GraphQL) |
+| Database | PostgreSQL via **Sequelize** (migrating off Prisma — see §6) |
+| Real-time | Socket.IO + Redis |
+| Queues | Bull + Redis |
+| Validation | Zod / Joi |
+| Native modules | 42 NAPI-RS workspace packages under `packages/*` |
+| Frontend | Separate Next.js 15 app in `frontend/` (App Router, Tailwind, React 19) |
+| Tests | Jest + Supertest (unit/integration), Cypress (e2e) |
+| Tooling | ESLint + Prettier, Husky + lint-staged, TypeDoc, Swagger |
+
+---
+
+## 2. Repository map (where things live)
+
+```
+src/                      # Main backend application
+├── api/                  # HTTP surface: controllers, routes, graphql
+│   ├── controllers/
+│   └── routes/
+├── core/                 # Cross-cutting platform: auth, cache, database,
+│                         #   errors, events, middleware, monitoring,
+│                         #   resilience, security, validation
+├── services/             # Domain business logic, grouped by domain
+│                         #   (asset, finance, space, workflow, portfolio…)
+├── shared/               # types / interfaces / constants (import via @/ aliases)
+├── graphql/              # Schema + resolvers
+├── config/  constants/  utils/  middleware/  database/
+└── index.ts              # App entry (run with `npm run dev`)
+
+packages/                 # 42 NAPI-RS native service packages (npm workspaces)
+frontend/                 # Next.js 15 web client (own package.json + lint)
+locales/                  # i18n resources (20+ languages)
+prisma/                   # Legacy schema — being phased out (see §6)
+docs/                     # Architecture + per-module API docs (napi-rs/)
+.development/             # Test config, scripts, cypress, validation, dev-only docs
+.claude/                  # Claude Code config: agents/ + settings.json
+```
+
+**Path aliases** (from `tsconfig.json`) — always prefer these over deep relative paths:
+
+```
+@/*            → src/*
+@/types/*      → src/shared/types/*
+@/interfaces/* → src/shared/interfaces/*
+@/constants/*  → src/shared/constants/*
+@/services/*   → src/services/*
+@/controllers/*→ src/api/controllers/*
+@/routes/*     → src/api/routes/*
+@/middleware/* → src/core/middleware/*
+@/utils/*      → src/core/utils/*
+@/config/*     → src/core/config/*
+@/database/*   → src/core/database/*
+```
+
+---
+
+## 3. Essential commands
+
+Run from the repo root unless noted. The frontend has its own scripts (`cd frontend`).
+
+| Task | Command |
+|------|---------|
+| Dev server (hot reload) | `npm run dev` |
+| Production build | `npm run build` (runs `clean` + `tsc`) |
+| Type-check only | `npm run type-check` |
+| Lint | `npm run lint` · fix: `npm run lint:fix` |
+| Format | `npm run format` · check: `npm run format:check` |
+| **Quality gate (all 3)** | `npm run quality` |
+| Unit/integration tests | `npm test` (Jest, config `.development/jest.config.js`) |
+| Watch tests | `npm run test:watch` |
+| Coverage | `npm run test:coverage` |
+| E2E (Cypress) | `npm run e2e` / `npm run cypress:open` |
+| Build all NAPI packages | `npm run build:napi` |
+| NAPI health check | `npm run napi:health` |
+| Frontend dev | `cd frontend && npm run dev` |
+
+**Before declaring work done, run `npm run quality` and the relevant tests.** The
+pre-commit hook (Husky + lint-staged) runs `eslint --fix` + `prettier` on staged
+`*.ts/tsx` and Prettier on `*.json/md`, so don't fight it — let it format.
+
+---
+
+## 4. Coding conventions
+
+- **Strict TypeScript.** `tsconfig.json` enables `strict`, `noUncheckedIndexedAccess`,
+  `exactOptionalPropertyTypes`, `noImplicitOverride`, and `noEmitOnError`. Write code
+  that compiles clean — do not paper over types with `any` or `@ts-ignore`.
+- **Imports:** use `@/` path aliases, not `../../../`.
+- **Services are the home for business logic.** Controllers stay thin (parse → validate
+  → delegate → respond). Cross-cutting concerns live in `src/core/*`.
+- **Validation at boundaries** with Zod/Joi; trust internal calls.
+- **Errors:** use the shared error types in `src/core/errors`, not ad-hoc `throw new Error`.
+- **No new top-level docs** unless asked. Summary/analysis markdown belongs in PR
+  descriptions, not the repo root (the root is already crowded — don't add to it).
+- **Comments:** only when the *why* is non-obvious. No "what" narration.
+- **`.backup` directories** (e.g. `src/services/*.backup`) are excluded from the build —
+  never edit them and never import from them.
+
+---
+
+## 5. Workflow rules
+
+- **Branch:** develop on the assigned feature branch; never push to `master` without
+  explicit permission.
+- **Commits:** small, descriptive, present-tense. Don't commit unless asked. Never use
+  `--no-verify` to skip hooks — fix the underlying lint/type error instead.
+- **PRs:** only open one when explicitly requested.
+- **Secrets:** never commit `.env`, keys, or credentials. `.env.example` documents the
+  shape; real values stay local.
+- **Risky/irreversible actions** (deleting branches, force-push, dropping tables,
+  `rm -rf`) require explicit confirmation first.
+
+---
+
+## 6. Critical gotcha: Prisma → Sequelize migration in progress
+
+The repo is **mid-migration from Prisma to Sequelize**. This matters for almost any
+data-layer task:
+
+- **Sequelize is the target.** New persistence code uses Sequelize / `sequelize-typescript`.
+- A **Prisma-compatibility adapter** exists so legacy call sites keep working during the
+  transition — see `SEQUELIZE_MIGRATION_GUIDE.md` and `SEQUELIZE_ADAPTER_ENHANCEMENTS.md`.
+- `npm run db:migrate` is intentionally a no-op pointer; migrations are managed
+  separately per the guide. Don't assume `prisma migrate` is wired up.
+- `prisma/` and `@prisma/client` are **legacy**. The README still references Prisma in
+  places — trust this file and the migration guides over the README for the data layer.
+
+When touching the database, read the migration guide first and follow the Sequelize
+path unless explicitly told otherwise.
+
+---
+
+## 7. Token efficiency — maximize signal, minimize waste
+
+Context is the scarce resource. Spend it deliberately. (See Anthropic's best-practices
+guide linked above.)
+
+**Searching & reading**
+- For broad/open-ended exploration ("where is X handled across the codebase?"), delegate
+  to the **`codebase-explorer`** subagent (§8). It burns its own context and returns a
+  tight summary, keeping your main window clean.
+- For a known symbol or string, use a **targeted `grep`/`rg`** — don't read whole files
+  to find one function.
+- Read **scoped line ranges**, not entire files, once you know the location.
+- Never re-read a file you just edited — the edit already confirmed its new state.
+- Don't dump large command output into context. Pipe through `head`, `grep`, or `wc`.
+
+**Parallelism & batching**
+- Fire independent tool calls **in a single message** (parallel) — e.g. read three files
+  at once, or run `git status` + `git diff` together.
+- Batch related edits; avoid round-trips.
+
+**Right tool / right model**
+- Cheap, mechanical search → Haiku-class subagents. Implementation → Sonnet.
+  Deep cross-system reasoning → Opus. Match cost to difficulty.
+- Lean on subagents to **parallelize independent work** and to **firewall noisy output**
+  (test logs, large greps) away from the main thread.
+
+**Don't waste effort**
+- No speculative refactors, abstractions, or "while I'm here" cleanups beyond the task.
+- Re-use prior findings instead of re-deriving them.
+
+---
+
+## 8. Subagent roster (`.claude/agents/`)
+
+Use the right specialist instead of doing everything inline. Each lives in
+`.claude/agents/` with a scoped tool set. Invoke proactively when the task matches.
+
+| Agent | Use it for |
+|-------|-----------|
+| **codebase-explorer** | Read-only search/navigation across `src/` and `packages/`. First stop for "where / how is X done?" Returns a concise map, not raw dumps. |
+| **service-architect** | Designing or scaffolding a new domain service or NAPI package that follows the controller→service→core layering and path-alias conventions. |
+| **test-runner** | Running Jest/Cypress, triaging failures, and reporting a fix-list. Keeps verbose test output out of the main context. |
+| **security-reviewer** | Reviewing a diff for OWASP issues, secret leakage, authZ gaps, and injection risks before commit. |
+| **docs-curator** | Keeping `CLAUDE.md`, `docs/`, and module docs accurate after code changes; flags drift. |
+
+To add or edit agents, follow https://docs.claude.com/en/docs/claude-code/sub-agents
+(markdown + YAML frontmatter: `name`, `description`, optional `tools`/`model`).
+
+---
+
+## 9. Security & enterprise expectations
+
+- Treat all external input (HTTP, GraphQL, file upload, integration payloads) as
+  untrusted. Validate and sanitize at the edge.
+- Enforce authZ in services, not just routes; respect `organizationId` tenancy on
+  `BaseEntity` records.
+- Use parameterized queries / ORM methods — never string-concatenate SQL.
+- Keep dependencies current; flag, don't silently downgrade, packages.
+- Log via Winston (`src/core/monitoring`), never `console.log` in committed code.
+- This is multi-tenant enterprise software — assume every record is scoped to an org and
+  every action is audited (`src/core/audit`).
+
+---
+
+## 10. When you're unsure
+
+Ask a focused question rather than guessing on anything ambiguous, irreversible, or
+architecturally significant. A 10-second clarification beats a wrong 10-minute build.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ locales/                  # i18n resources (20+ languages)
 prisma/                   # Legacy schema — being phased out (see §6)
 docs/                     # Architecture + per-module API docs (napi-rs/)
 .development/             # Test config, scripts, cypress, validation, dev-only docs
-.claude/                  # Claude Code config: agents/ + settings.json
+.claude/                  # Claude Code config: agents/ + skills/ + settings.json
 ```
 
 **Path aliases** (from `tsconfig.json`) — always prefer these over deep relative paths:
@@ -205,6 +205,16 @@ Use the right specialist instead of doing everything inline. Each lives in
 
 To add or edit agents, follow https://docs.claude.com/en/docs/claude-code/sub-agents
 (markdown + YAML frontmatter: `name`, `description`, optional `tools`/`model`).
+
+### Skills (`.claude/skills/`)
+
+Skills are repeatable **workflows** Claude runs in the main thread (invoke with
+`/<skill-name>`), as opposed to agents, which are delegated workers. See
+https://docs.claude.com/en/docs/claude-code/skills.
+
+| Skill | Use it for |
+|-------|-----------|
+| **pr-readiness** | Pre-PR gate: runs the quality gate + relevant tests, pulls in the security-reviewer and docs-curator agents, and returns a go/no-go punch list. Run it before opening any PR. |
 
 ---
 

--- a/frontend/.github/copilot-instructions.md
+++ b/frontend/.github/copilot-instructions.md
@@ -1,130 +1,48 @@
-<!-- Use this fi- [ ] Customize t- [x] Install Required Extensions - No extensions needed for Next.js.
-	<!-- ONLY install extensions provided mentioned in the get_project_setup_info. Skip this step otherwise and mark as completed. -->
+# AI assistant instructions — Turbo Asset frontend
 
-- [x] Compile the Project - Project built successfully with no errors.
-	<!--
-	Verify that all previous steps have been completed.
-	Install any missing dependencies.
-	Run diagnostics and resolve any issues.
-	Check for markdown files in project folder for relevant instructions on how to do this.
-	-->
+Guidance for AI coding assistants (GitHub Copilot, Claude, etc.) working in the
+`frontend/` web client. The repository-wide operating guide is **`../../CLAUDE.md`** —
+read it first; this file only adds frontend-specific notes.
 
-- [x] Create and Run Task - No custom task needed for Next.js.
-	<!--
-	Verify that all previous steps have been completed.
-	Check https://code.visualstudio.com/docs/debugtest/tasks to determine if the project needs a task. If so, use the create_and_run_task to create and launch a task based on package.json, README.md, and project structure.
-	Skip this step otherwise.
-	 -->
-	Verify that all previous steps have been marked as completed successfully and you have marked the step as completed.
-	Develop a plan to modify codebase according to user requirements.
-	Apply modifications using appropriate tools and user-provided references.
-	Skip this step for "Hello World" projects.
-	-->
+## What this is
+The Turbo Asset web client: a **Next.js 15** app (App Router) using **React 19**,
+**TypeScript**, and **Tailwind CSS**. It renders UI for the IWMS services exposed by the
+backend in `../src`.
 
-- [x] Install Required Extensions - No extensions needed for Next.js.
-	<!-- ONLY install extensions provided mentioned in the get_project_setup_info. Skip this step otherwise and mark as completed. -->ide workspace-specific custom instructions to Copilot. For more details, visit https://code.visualstudio.com/docs/copilot/copilot-customization#_use-a-githubcopilotinstructionsmd-file -->
-- [x] Verify that the copilot-instructions.md file in the .github directory is created.
+## Layout
+```
+frontend/src/
+├── app/         # Next.js App Router routes (pages, layouts, route handlers)
+├── components/  # Reusable UI components
+├── services/    # API client code that talks to the backend
+└── lib/         # Shared helpers/utilities
+```
 
-- [x] Clarify Project Requirements - React project for UI pages for services.
-	<!-- Ask for project type, language, and frameworks if not specified. Skip if already provided. -->
+## Commands (run inside `frontend/`)
+| Task | Command |
+|------|---------|
+| Dev server | `npm run dev` (Turbopack, http://localhost:3000) |
+| Production build | `npm run build` |
+| Start built app | `npm run start` |
+| Lint | `npm run lint` |
 
-- [x] Scaffold the Project - Next.js project scaffolded with TypeScript, Tailwind CSS, ESLint, and App Router.
-	<!--
-	Ensure that the previous step has been marked as completed.
-	Call project setup tool with projectType parameter.
-	Run scaffolding command to create project files and folders.
-	Use '.' as the working directory.
-	If no appropriate projectType is available, search documentation using available tools.
-	Otherwise, create the project structure manually using available file creation tools.
-	-->
+## Conventions
+- **App Router patterns:** prefer Server Components; add `"use client"` only when a
+  component needs interactivity/browser APIs.
+- **TypeScript first** — type props and API responses; avoid `any`.
+- **Styling:** Tailwind utility classes; compose with `clsx` / `tailwind-merge` (already
+  dependencies). Don't introduce a second styling system.
+- **Data fetching:** go through `src/services/*`; don't scatter raw `fetch` calls through
+  components.
+- **Match existing components** before inventing new patterns — read a sibling first.
+- Keep secrets out of client code; only `NEXT_PUBLIC_*` env vars are exposed to the browser.
 
-- [x] Customize the Project - Created React UI pages for all services with a dashboard home page.
-	<!--
-	Verify that all previous steps have been completed successfully and you have marked the step as completed.
-	Develop a plan to modify codebase according to user requirements.
-	Apply modifications using appropriate tools and user-provided references.
-	Skip this step for "Hello World" projects.
-	-->
+## Token-efficient workflow
+- Locate code with a targeted search before reading; read scoped ranges, not whole files.
+- Make independent reads/edits in parallel; don't re-read a file you just changed.
+- After a change, run `npm run lint` and verify the affected page in the browser before
+  declaring it done.
 
-- [ ] Install Required Extensions
-	<!-- ONLY install extensions provided mentioned in the get_project_setup_info. Skip this step otherwise and mark as completed. -->
-
-- [ ] Compile the Project
-	<!--
-	Verify that all previous steps have been completed.
-	Install any missing dependencies.
-	Run diagnostics and resolve any issues.
-	Check for markdown files in project folder for relevant instructions on how to do this.
-	-->
-
-- [ ] Create and Run Task
-	<!--
-	Verify that all previous steps have been completed.
-	Check https://code.visualstudio.com/docs/debugtest/tasks to determine if the project needs a task. If so, use the create_and_run_task to create and launch a task based on package.json, README.md, and project structure.
-	Skip this step otherwise.
-	 -->
-
-- [x] Launch the Project - Development server started on http://localhost:3000.
-	<!--
-	Verify that all previous steps have been completed.
-	Prompt user for debug mode, launch only if confirmed.
-	 -->
-
-- [x] Ensure Documentation is Complete - README.md updated with project details.
-	<!--
-	Verify that all previous steps have been completed.
-	Verify that README.md and the copilot-instructions.md file in the .github directory exists and contains current project information.
-	Clean up the copilot-instructions.md file in the .github directory by removing all HTML comments.
-	 -->
-
-<!--
-## Execution Guidelines
-PROGRESS TRACKING:
-- If any tools are available to manage the above todo list, use it to track progress through this checklist.
-- After completing each step, mark it complete and add a summary.
-- Read current todo list status before starting each new step.
-
-COMMUNICATION RULES:
-- Avoid verbose explanations or printing full command outputs.
-- If a step is skipped, state that briefly (e.g. "No extensions needed").
-- Do not explain project structure unless asked.
-- Keep explanations concise and focused.
-
-DEVELOPMENT RULES:
-- Use '.' as the working directory unless user specifies otherwise.
-- Avoid adding media or external links unless explicitly requested.
-- Use placeholders only with a note that they should be replaced.
-- Use VS Code API tool only for VS Code extension projects.
-- Once the project is created, it is already opened in Visual Studio Code—do not suggest commands to open this project in Visual Studio again.
-- If the project setup information has additional rules, follow them strictly.
-
-FOLDER CREATION RULES:
-- Always use the current directory as the project root.
-- If you are running any terminal commands, use the '.' argument to ensure that the current working directory is used ALWAYS.
-- Do not create a new folder unless the user explicitly requests it besides a .vscode folder for a tasks.json file.
-- If any of the scaffolding commands mention that the folder name is not correct, let the user know to create a new folder with the correct name and then reopen it again in vscode.
-
-EXTENSION INSTALLATION RULES:
-- Only install extension specified by the get_project_setup_info tool. DO NOT INSTALL any other extensions.
-
-PROJECT CONTENT RULES:
-- If the user has not specified project details, assume they want a "Hello World" project as a starting point.
-- Avoid adding links of any type (URLs, files, folders, etc.) or integrations that are not explicitly required.
-- Avoid generating images, videos, or any other media files unless explicitly requested.
-- If you need to use any media assets as placeholders, let the user know that these are placeholders and should be replaced with the actual assets later.
-- Ensure all generated components serve a clear purpose within the user's requested workflow.
-- If a feature is assumed but not confirmed, prompt the user for clarification before including it.
-- If you are working on a VS Code extension, use the VS Code API tool with a query to find relevant VS Code API references and samples related to that query.
-
-TASK COMPLETION RULES:
-- Your task is complete when:
-  - Project is successfully scaffolded and compiled without errors
-  - copilot-instructions.md file in the .github directory exists in the project
-  - README.md file exists and is up to date
-  - User is provided with clear instructions to debug/launch the project
-
-Before starting a new task in the above plan, update progress in the plan.
--->
-- Work through each checklist item systematically.
-- Keep communication concise and focused.
-- Follow development best practices.
+For everything else — coding standards, security expectations, the Prisma→Sequelize note,
+and the subagent roster — see `../../CLAUDE.md` and Anthropic's Claude Code docs at
+https://docs.claude.com/en/docs/claude-code/overview.


### PR DESCRIPTION
Introduce a root CLAUDE.md as the authoritative LLM guidance for the
monorepo: project map, commands, conventions, the Prisma->Sequelize
migration gotcha, token-efficiency practices, and references to the
official Anthropic Claude Code docs. Add a curated .claude/agents/
roster (codebase-explorer, service-architect, test-runner,
security-reviewer, docs-curator) and a project settings.json that
allowlists safe read-only/quality commands while protecting secrets.
Replace the corrupted frontend Copilot instructions with clean,
Claude-aligned guidance that defers to the root guide.

https://claude.ai/code/session_01XNxBcxpyWdtjJNNZLUokod

## Summary by Sourcery

Add a repository-wide LLM operating guide and Claude configuration, and align frontend AI assistant instructions with it.

Enhancements:
- Add a curated set of Claude subagents (codebase-explorer, service-architect, test-runner, security-reviewer, docs-curator) and a pr-readiness skill to structure AI-assisted development workflows in this repo.
- Document the responsibilities and usage patterns for Claude agents and skills, including security expectations and pre-PR readiness checks.

Documentation:
- Introduce CLAUDE.md as the authoritative, high-signal operating guide for Claude/LLMs in the monorepo, covering architecture, workflows, migration notes, and token-efficiency practices.
- Replace the frontend Copilot instructions with concise, Claude-aligned guidance specific to the Next.js web client and pointing back to the root guide.