### PR TITLE
Refine Claude Code config for token efficiency and enforced safeguards

### DIFF
--- a/.claude/agents/codebase-explorer.md
+++ b/.claude/agents/codebase-explorer.md
@@ -9,6 +9,9 @@ description: >
   so it protects the main context window. Do NOT use it to write or edit code.
 tools: Read, Grep, Glob, Bash
 model: haiku
+maxTurns: 25
+memory: user
+color: cyan
 ---
 
 You are a code-navigation specialist for **Turbo Asset**, a TypeScript IWMS monorepo
@@ -19,22 +22,27 @@ You are a code-navigation specialist for **Turbo Asset**, a TypeScript IWMS mono
 Locate things and explain how they connect — fast and cheaply. You are read-only.
 
 ## How to work
-1. Start broad with `grep`/`rg` and `glob`, then narrow. Search both `src/` and
-   `packages/` unless the request scopes it.
-2. Respect the path aliases (`@/services`, `@/core`, etc. — see `tsconfig.json`) when
+1. Check your memory first — if you've already mapped this area, verify it's still
+   accurate with one targeted grep instead of re-exploring from scratch.
+2. Start broad with `grep`/`rg` and `glob`, then narrow. Fire **independent searches in
+   parallel in one message**. Search both `src/` and `packages/` unless scoped.
+3. Respect the path aliases (`@/services`, `@/core`, etc. — see `tsconfig.json`) when
    mapping imports to real files.
-3. Read only the **line ranges** you need to confirm a finding — never whole files just
+4. Read only the **line ranges** you need to confirm a finding — never whole files just
    to skim.
-4. Ignore `node_modules/`, `dist/`, `.next/`, and `*.backup/` directories — they are
+5. Ignore `node_modules/`, `dist/`, `.next/`, and `*.backup/` directories — they are
    noise or excluded from the build.
-5. Account for naming variation in this repo: domains appear in both `src/services/<domain>`
-   and `packages/<domain>-service`, and some folders have `-management` siblings.
+6. Account for naming variation: domains appear in both `src/services/<domain>` and
+   `packages/<domain>-service`, and some folders have `-management` siblings.
+7. Save durable structural learnings (domain layouts, naming quirks, dead ends) to your
+   memory so future explorations start warmer.
 
 ## What to return
 A tight report, not transcripts:
 - A bulleted list of relevant locations as `path:line — what it is`.
 - A 2–4 sentence synthesis of how the pieces fit together.
-- Explicit gaps: "did not find X" or "ambiguous between A and B."
+- Explicit gaps: "did not find X" or "ambiguous between A and B." Never guess a
+  location you didn't verify.
 
-Keep output under ~300 words unless the caller asks for more. Never paste large blocks
-of source — cite the location instead.
+Hard budget: keep output under ~300 words unless the caller asks for more. Never paste
+large blocks of source — cite the location instead.

--- a/.claude/agents/docs-curator.md
+++ b/.claude/agents/docs-curator.md
@@ -3,12 +3,15 @@ name: docs-curator
 description: >
   Keeps Turbo Asset's documentation accurate and consistent after code changes. Use when
   a change alters commands, structure, architecture, the data layer, API surface, or
-  conventions — to update CLAUDE.md, docs/, frontend/.github/copilot-instructions.md, and
-  the per-module docs under docs/napi-rs/modules. Also use to audit docs for drift
-  (e.g. stale Prisma references, wrong commands, dead links). Edits documentation only;
-  it does not change application code.
+  conventions — to update CLAUDE.md, .claude/rules/, docs/,
+  frontend/.github/copilot-instructions.md, and the per-module docs under
+  docs/napi-rs/modules. Also use to audit docs for drift (e.g. stale Prisma references,
+  wrong commands, dead links). Edits documentation only; it does not change application
+  code.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: sonnet
+maxTurns: 30
+color: green
 ---
 
 You are the documentation curator for **Turbo Asset**. You edit docs to match reality;
@@ -17,19 +20,26 @@ you do not touch application code.
 ## Principles
 - **Accuracy over volume.** Docs that lie are worse than no docs. Verify claims against
   the code and `package.json` scripts before writing them.
-- **CLAUDE.md is high-signal config**, not a wiki — every token is sent on each request.
-  Keep edits tight; cut redundancy. Mirror Anthropic's guidance
-  (https://docs.claude.com/en/docs/claude-code/memory).
+- **CLAUDE.md is high-signal config**, not a wiki — it is loaded on every request and
+  must stay under ~200 lines. Area-specific detail belongs in path-scoped
+  `.claude/rules/*.md` files (loaded only when matching files are touched), not in
+  CLAUDE.md. Block-level HTML comments in CLAUDE.md are stripped from context — use
+  them for maintainer notes. Mirror Anthropic's guidance:
+  https://code.claude.com/docs/en/memory.
+- **Keep the three layers consistent:** CLAUDE.md (always-loaded core), `.claude/rules/`
+  (path-scoped detail), and `.claude/settings.json` hooks (enforcement). If a rule moves
+  layers, remove it from the old one — duplicated rules drift and conflict.
 - **Don't create new top-level markdown** unless explicitly asked — the repo root is
-  already crowded with summary docs. Prefer editing the right existing file.
-- Use real, working links. Anthropic docs live under `https://docs.claude.com/...`.
+  already crowded. Prefer editing the right existing file.
+- Use real, working links. Claude Code docs live under `https://code.claude.com/docs/...`.
 
 ## Known drift to watch for
 - **Prisma → Sequelize:** the data layer is migrating to Sequelize; the README still
   references Prisma in places. Flag and correct stale Prisma instructions; point to
-  `SEQUELIZE_MIGRATION_GUIDE.md`.
+  `SEQUELIZE_MIGRATION_GUIDE.md` and `.claude/rules/data-layer.md`.
 - Command names must match `package.json` scripts exactly.
 - Path aliases and directory names must match `tsconfig.json` and the actual tree.
+- `.claude/rules/*.md` `paths:` globs must still match real directories after renames.
 
 ## How to work
 1. Read the code/config that the doc describes; confirm before editing.

--- a/.claude/agents/security-reviewer.md
+++ b/.claude/agents/security-reviewer.md
@@ -9,6 +9,9 @@ description: >
   external integrations. Read-only and advisory — it reports findings, it does not commit.
 tools: Read, Grep, Glob, Bash
 model: sonnet
+maxTurns: 30
+memory: user
+color: red
 ---
 
 You are an application security reviewer for **Turbo Asset**, a multi-tenant enterprise
@@ -17,7 +20,8 @@ IWMS. You review code for vulnerabilities; you do not change or commit it.
 ## Scope
 By default review the working diff: `git diff` (unstaged) and `git diff --cached`
 (staged). Use `git status` to see untracked files. If the caller names specific files,
-review those.
+review those. Review the **diff plus the minimum surrounding context** needed to judge
+it — don't audit the whole repo unless asked.
 
 ## What to look for
 - **Injection:** raw SQL string-building instead of Sequelize parameterized queries;
@@ -34,8 +38,12 @@ review those.
   backends.
 - **Crypto & auth:** weak hashing, JWT misuse, missing rate limiting on sensitive routes.
 
+Record recurring weakness patterns you find in this codebase to your memory, and check
+memory at the start of a review — repeat offenders deserve a targeted grep.
+
 ## How to report
 Group findings by severity (Critical / High / Medium / Low). For each:
 `severity — file:line — the issue — concrete fix`.
 Cite the relevant OWASP category where it helps. If the diff is clean, say so plainly and
-note anything you could not fully verify. Be precise; do not invent issues to fill space.
+note anything you could not fully verify. Be precise; do not invent issues to fill space,
+and do not bury one Critical under ten Lows — lead with what matters.

--- a/.claude/agents/service-architect.md
+++ b/.claude/agents/service-architect.md
@@ -9,9 +9,12 @@ description: >
   data layer. Not for one-line fixes — use it when structure and consistency matter.
 tools: Read, Grep, Glob, Edit, Write, Bash
 model: sonnet
+color: purple
 ---
 
 You are a senior backend architect for **Turbo Asset**, an enterprise IWMS platform.
+The path-scoped rules in `.claude/rules/` (backend-conventions, data-layer, security,
+napi-packages) load as you touch matching files — they are binding, not advisory.
 
 ## Conventions you MUST follow
 - **Layering:** HTTP controllers (`src/api/controllers`) stay thin — parse, validate,
@@ -33,7 +36,8 @@ You are a senior backend architect for **Turbo Asset**, an enterprise IWMS platf
   existing sibling package, including its `package.json` name `@turbo-asset/<name>`.
 
 ## How to work
-1. Confirm the desired surface (REST? GraphQL? package?) and the closest existing pattern.
+1. Confirm the desired surface (REST? GraphQL? package?) and the closest existing
+   pattern. Read the reference with scoped line ranges, not whole-directory dumps.
 2. Scaffold minimally and completely — no half-finished stubs, no speculative extras.
 3. Run `npm run type-check` and `npm run lint` on what you touched; fix issues before
    handing back.

--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -9,6 +9,8 @@ description: >
   defers larger changes to the caller.
 tools: Read, Grep, Glob, Bash, Edit
 model: sonnet
+maxTurns: 40
+color: yellow
 ---
 
 You are the test specialist for **Turbo Asset** (Jest + Supertest for unit/integration,
@@ -22,16 +24,22 @@ Cypress for e2e). Jest config: `.development/jest.config.js`.
 - Type safety often matters as much as tests: `npm run type-check`
 
 ## How to work
-1. Run the **narrowest** relevant tests first; only run the full suite when scope is broad
-   or when asked.
-2. On failure, read the failing test and the code under test to find the **root cause** —
+1. Run the **narrowest** relevant tests first; only run the full suite when scope is
+   broad or when asked.
+2. Keep your own context lean too: pipe long runs through `tail`/`grep` for the failure
+   summary instead of ingesting full logs; re-run single tests with `-t '<name>'` to
+   isolate.
+3. On failure, read the failing test and the code under test to find the **root cause** —
    distinguish a real product bug from a stale/incorrect test.
-3. Apply a fix only when it is small and unambiguous (e.g. updated assertion for an
+4. Apply a fix only when it is small and unambiguous (e.g. updated assertion for an
    intentional change). For anything larger or design-affecting, report and defer.
-4. Never weaken a test just to make it pass, and never use `--no-verify` or skip hooks.
+5. Never weaken a test, add `.skip`, or loosen an assertion just to make it pass. Never
+   use `--no-verify` or skip hooks (a repo guard blocks it anyway).
+6. Distinguish **flaky** from **broken**: if a failure doesn't reproduce on a second
+   targeted run, say so explicitly rather than chasing it.
 
 ## What to return
-- One-line verdict: ✅ all green / ❌ N failing.
+- One-line verdict: ✅ all green / ❌ N failing (and the exact command you ran).
 - Per failure: test name, the real cause (file:line), and the recommended fix.
 - What you changed, if anything, and what the caller should still do.
 

--- a/.claude/hooks/guard.cjs
+++ b/.claude/hooks/guard.cjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * PreToolUse guard for Turbo Asset.
+ *
+ * CLAUDE.md instructions are advisory context; hooks are the enforcement layer
+ * (https://code.claude.com/docs/en/hooks). This guard enforces the repo's
+ * non-negotiables: it denies irreversible-by-policy actions outright and
+ * escalates merely-risky ones to an explicit permission prompt ("ask").
+ *
+ * Wired in .claude/settings.json for Bash and Edit/Write/NotebookEdit.
+ * Always exits 0; decisions are returned as PreToolUse JSON on stdout.
+ */
+
+'use strict';
+
+function deny(reason) {
+  return { action: 'deny', reason };
+}
+
+function ask(reason) {
+  return { action: 'ask', reason };
+}
+
+function checkBash(cmd) {
+  if (/\bgit\b/.test(cmd) && /--no-verify\b/.test(cmd)) {
+    return deny(
+      'Skipping git hooks (--no-verify) is forbidden (CLAUDE.md §5). Fix the underlying lint/type error instead.'
+    );
+  }
+  if (/\bgit\s+push\b/.test(cmd) && /--force-with-lease\b/.test(cmd)) {
+    return ask('Force-with-lease push — requires explicit user confirmation (CLAUDE.md §5).');
+  }
+  if (/\bgit\s+push\b/.test(cmd) && /(\s-f\b|--force\b)/.test(cmd)) {
+    return deny('Force-push is blocked. If history must move, get explicit user approval and use --force-with-lease.');
+  }
+  if (/\bgit\s+push\b[^|;&]*\s(master|main)(\s|$)/.test(cmd) || /\bgit\s+push\b[^|;&]*:(master|main)(\s|$)/.test(cmd)) {
+    return ask('Pushing to master/main requires explicit user permission (CLAUDE.md §5).');
+  }
+  if (/\brm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)[a-zA-Z]*\b/.test(cmd)) {
+    return ask('rm -rf is irreversible — requires explicit user confirmation (CLAUDE.md §5).');
+  }
+  if (/\bgit\s+(reset\s+--hard|clean\s+-[a-zA-Z]*f|branch\s+(-D|--delete\s+--force)|push\s+[^|;&]*--delete)\b/.test(cmd)) {
+    return ask('Destructive git operation — requires explicit user confirmation (CLAUDE.md §5).');
+  }
+  if (/\bprisma\s+(migrate|db\s+push)\b/.test(cmd)) {
+    return deny(
+      'Prisma migrations are not wired up — the data layer is migrating to Sequelize. See SEQUELIZE_MIGRATION_GUIDE.md and .claude/rules/data-layer.md.'
+    );
+  }
+  return null;
+}
+
+function checkWritePath(rawPath) {
+  const p = String(rawPath).replace(/\\/g, '/');
+  const base = p.split('/').pop() || '';
+  if (base.startsWith('.env') && base !== '.env.example') {
+    return deny('Never write secrets/.env files (CLAUDE.md §5). Document the shape in .env.example instead.');
+  }
+  if (/(^|\/)[^/]*\.backup(\/|$)/.test(p)) {
+    return deny('*.backup directories are excluded from the build — never edit them (CLAUDE.md §4).');
+  }
+  if (/(^|\/)(node_modules|dist|\.next)\//.test(p)) {
+    return deny('Generated or vendored path — edit the source, not build output.');
+  }
+  return null;
+}
+
+function evaluate(input) {
+  const tool = input.tool_name;
+  const ti = input.tool_input || {};
+  if (tool === 'Bash') return checkBash(String(ti.command || ''));
+  if (tool === 'Edit' || tool === 'Write') return checkWritePath(ti.file_path || '');
+  if (tool === 'NotebookEdit') return checkWritePath(ti.notebook_path || '');
+  return null;
+}
+
+let raw = '';
+process.stdin.on('data', (chunk) => (raw += chunk));
+process.stdin.on('end', () => {
+  let input;
+  try {
+    input = JSON.parse(raw);
+  } catch {
+    process.exit(0);
+  }
+  const decision = evaluate(input);
+  if (decision) {
+    process.stdout.write(
+      JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: 'PreToolUse',
+          permissionDecision: decision.action,
+          permissionDecisionReason: decision.reason,
+        },
+      })
+    );
+  }
+  process.exit(0);
+});

--- a/.claude/rules/backend-conventions.md
+++ b/.claude/rules/backend-conventions.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "src/**/*.ts"
+---
+
+# Backend conventions (src/)
+
+- **Layering:** controllers (`src/api/controllers`) stay thin — parse → validate →
+  delegate → respond. Business logic lives in `src/services/<domain>`. Cross-cutting
+  concerns (auth, cache, database, errors, events, middleware, monitoring, resilience,
+  security, validation) live in `src/core/*`. Routes in `src/api/routes`.
+- **Mirror an existing example first.** Before writing a new controller/service/route,
+  read a comparable one and match its structure, error handling, and naming.
+- **Strict TypeScript:** must compile under `strict`, `noUncheckedIndexedAccess`,
+  `exactOptionalPropertyTypes`, `noImplicitOverride`, `noEmitOnError`. No `any`,
+  no `@ts-ignore`, no casting around the type system.
+- **Imports:** `@/` path aliases from `tsconfig.json` (`@/services/*`, `@/controllers/*`,
+  `@/middleware/*`, `@/utils/*`, `@/config/*`, `@/database/*`, `@/types/*`,
+  `@/interfaces/*`, `@/constants/*`, `@/routes/*`) — never deep relative paths.
+- **Validation** with Zod/Joi at external boundaries (HTTP, GraphQL, uploads,
+  integration payloads); trust internal calls.
+- **Errors:** shared types from `src/core/errors`, never ad-hoc `throw new Error`.
+- **Logging:** Winston via `src/core/monitoring` — `console.log` never ships.
+- **Real-time / queues:** Socket.IO + Redis for events, Bull + Redis for jobs — reuse
+  the existing wiring in `src/core/events`, don't create parallel infrastructure.

--- a/.claude/rules/data-layer.md
+++ b/.claude/rules/data-layer.md
@@ -1,0 +1,25 @@
+---
+paths:
+  - "src/database/**"
+  - "src/services/**/*.ts"
+  - "prisma/**"
+  - "src/core/database/**"
+---
+
+# Data layer: Prisma → Sequelize migration
+
+The repo is **mid-migration from Prisma to Sequelize**. Read
+`SEQUELIZE_MIGRATION_GUIDE.md` before touching persistence code.
+
+- **Sequelize is the target.** All new persistence uses Sequelize /
+  `sequelize-typescript`. Never add new Prisma code or new models to `prisma/schema.prisma`.
+- A **Prisma-compatibility adapter** keeps legacy call sites working during the
+  transition — see `SEQUELIZE_ADAPTER_ENHANCEMENTS.md`. Prefer porting a call site to
+  native Sequelize over extending the adapter.
+- `npm run db:migrate` is intentionally a no-op pointer; `prisma migrate` is **not**
+  wired up (a hook blocks it). Migrations are managed per the guide.
+- The README still references Prisma in places — trust CLAUDE.md and the migration
+  guides over the README for anything data-layer.
+- **Multi-tenancy is non-negotiable:** every query on `BaseEntity` records is scoped by
+  `organizationId`. A missing tenancy scope is a security bug, not a style issue.
+- Use parameterized queries / ORM methods only — never string-concatenate SQL.

--- a/.claude/rules/frontend.md
+++ b/.claude/rules/frontend.md
@@ -1,0 +1,19 @@
+---
+paths:
+  - "frontend/**"
+---
+
+# Frontend (Next.js app)
+
+Separate app with its own `package.json`, lint config, and conventions — see
+`frontend/.github/copilot-instructions.md` for the full guide.
+
+- Stack: Next.js 15 App Router, React 19, Tailwind. Run commands from `frontend/`
+  (`cd frontend && npm run dev` / `npm run lint`).
+- Root-level `npm run quality` does **not** cover the frontend; lint it separately when
+  you change it.
+- Server Components by default; add `"use client"` only when interaction requires it.
+- Talk to the backend through the existing API client layer — don't scatter raw `fetch`
+  calls with hard-coded URLs.
+- i18n: user-facing strings go through the locale resources (`locales/`, 20+ languages),
+  not inline literals.

--- a/.claude/rules/napi-packages.md
+++ b/.claude/rules/napi-packages.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "packages/**"
+---
+
+# NAPI-RS packages (packages/*)
+
+42 native service packages managed as npm workspaces.
+
+- Package names follow `@turbo-asset/<name>`; mirror the layout of an existing sibling
+  package (its `package.json`, build scripts, and module docs) before creating anything.
+- Build all: `npm run build:napi`. Health check: `npm run napi:health`.
+- Per-module API docs live under `docs/napi-rs/modules/` — update the matching doc (or
+  delegate to **docs-curator**) when a package's surface changes.
+- Domains can exist in both `src/services/<domain>` and `packages/<domain>-service`
+  (sometimes with `-management` siblings) — confirm which one a task targets before
+  editing.

--- a/.claude/rules/security.md
+++ b/.claude/rules/security.md
@@ -1,0 +1,29 @@
+---
+paths:
+  - "src/api/**"
+  - "src/graphql/**"
+  - "src/core/**"
+  - "src/middleware/**"
+---
+
+# Security requirements (API, GraphQL, core)
+
+Turbo Asset is multi-tenant enterprise software: assume every record is org-scoped and
+every action is audited (`src/core/audit`).
+
+- **All external input is untrusted** — HTTP bodies/params, GraphQL args, file uploads,
+  integration payloads (SAP/Oracle/Workday/ServiceNow, REST/SOAP connectors). Validate
+  and sanitize with Zod/Joi at the edge.
+- **AuthZ in services, not just routes.** Route middleware is the first gate, not the
+  only one; service methods re-check permissions and `organizationId` ownership (IDOR
+  prevention).
+- **Tenancy:** every query respects `organizationId` on `BaseEntity` records.
+- **Injection:** ORM methods / parameterized queries only; no string-built SQL, no
+  `eval`/dynamic `require`, no shelling out with user input.
+- **SSRF:** outbound URLs in integration connectors must come from validated/allowlisted
+  config, never raw user input.
+- **Uploads:** enforce content type, size limits, and path-traversal-safe storage.
+- **Secrets:** never hard-code or log keys/tokens/connection strings; `.env` writes are
+  hook-blocked. Rate-limit sensitive routes; use the shared auth/JWT helpers in
+  `src/core/auth` rather than rolling crypto.
+- Significant diffs here warrant a pass from the **security-reviewer** agent before commit.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,24 @@
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - "**/__tests__/**"
+  - ".development/**"
+  - "frontend/cypress/**"
+---
+
+# Testing conventions
+
+- Jest + Supertest for unit/integration (config: `.development/jest.config.js`),
+  Cypress for e2e.
+- Run the **narrowest** scope that covers the change: `npm test -- <path-or-pattern>`.
+  Full `npm test` only for broad/cross-cutting changes. Coverage: `npm run test:coverage`.
+- Long or noisy runs belong in the **test-runner** agent, not the main context — use its
+  summary, never paste raw logs.
+- Never weaken an assertion, add `.skip`, or loosen a type just to get green. A failing
+  test is either a product bug (fix the product) or a stale test (fix it explicitly and
+  say so).
+- Tests live next to the patterns they cover — mirror an existing spec's structure,
+  factories, and naming before inventing new helpers.
+- Multi-tenancy in tests: cover the `organizationId` boundary (one org must not read
+  another's records) for any service-layer test that touches persistence.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,16 +12,64 @@
       "Bash(npm test:*)",
       "Bash(npm run test:coverage)",
       "Bash(npm run napi:health)",
+      "Bash(npm ls:*)",
+      "Bash(node --version)",
       "Bash(git status:*)",
       "Bash(git diff:*)",
       "Bash(git log:*)",
       "Bash(git branch:*)",
-      "Bash(git show:*)"
+      "Bash(git show:*)",
+      "Bash(git fetch:*)",
+      "Bash(git stash list:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)"
     ],
     "deny": [
       "Read(./.env)",
       "Read(./.env.local)",
-      "Read(./.env.production)"
+      "Read(./.env.development)",
+      "Read(./.env.test)",
+      "Read(./.env.production)",
+      "Read(**/.env)",
+      "Read(**/.env.local)",
+      "Read(**/.env.production)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Edit(**/.env)",
+      "Edit(**/.env.*)",
+      "Write(**/.env)",
+      "Write(**/.env.*)",
+      "Edit(**/*.backup/**)",
+      "Write(**/*.backup/**)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/guard.cjs"],
+            "timeout": 10,
+            "statusMessage": "Checking repo safeguards"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PROJECT_DIR}/.claude/hooks/guard.cjs"],
+            "timeout": 10,
+            "statusMessage": "Checking repo safeguards"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/pr-readiness/SKILL.md
+++ b/.claude/skills/pr-readiness/SKILL.md
@@ -11,47 +11,63 @@ description: >
 # PR readiness gate
 
 Drive the change to a confident, reviewable state. Work the steps in order; stop and
-report early only if something blocks the rest.
+report early only if something blocks the rest. Context hygiene applies throughout:
+summarize command results, never paste full logs, and delegate anything noisy to a
+subagent.
 
 ## 1. Establish scope
-- `git status` and `git diff --stat` against the base branch to see what actually changed.
+
+- `git status` and `git diff --stat` against the base branch (run both in one message)
+  to see what actually changed.
 - Note which areas are touched: backend (`src/`), a `packages/*` workspace, `frontend/`,
-  docs, or config. This decides which checks below are relevant.
+  docs, or config. This decides which checks below are relevant — skip checks whose
+  area is untouched and say so in the report.
 
 ## 2. Quality gate
-Run the root quality gate and capture failures (don't paste full logs — summarize):
+
 - `npm run quality` (lint + format:check + type-check). If it's noisy, run the pieces
-  individually: `npm run lint`, `npm run format:check`, `npm run type-check`.
-- If only `frontend/` changed, also run `cd frontend && npm run lint`.
-- Fix mechanical issues (`npm run lint:fix`, `npm run format`) rather than reporting them.
-  Never silence errors with `any`/`@ts-ignore` or by skipping hooks.
+  individually and pipe through `tail` for the failure summary.
+- If `frontend/` changed, also run `cd frontend && npm run lint`.
+- Fix mechanical issues (`npm run lint:fix`, `npm run format`) rather than reporting
+  them. Never silence errors with `any`/`@ts-ignore`; never bypass hooks (`--no-verify`
+  is blocked by a repo guard anyway).
 
-## 3. Tests
-- Run the **narrowest** suite that covers the change: `npm test -- <path-or-pattern>`.
-  Run the full `npm test` only when the change is broad or cross-cutting.
-- For UI changes, note whether Cypress e2e (`npm run e2e`) is warranted; flag if it can't
-  be run here.
-- Prefer delegating long/noisy runs to the **test-runner** subagent so logs stay out of the
-  main context — use its summary.
+## 3. Tests + security — delegate in parallel
 
-## 4. Security & data-layer review
-- If the diff touches auth, the data layer, HTTP/GraphQL surfaces, file uploads, or
-  integration connectors, delegate to the **security-reviewer** subagent and fold its
-  findings into the punch list.
-- Confirm no secrets are staged (`.env`, keys, tokens) and that new persistence code uses
-  **Sequelize**, not Prisma (see `SEQUELIZE_MIGRATION_GUIDE.md`).
+Launch both subagents **in a single message** so they run concurrently in their own
+context windows:
+
+- **test-runner**: the narrowest suite covering the change (`npm test -- <path>`); full
+  `npm test` only for broad/cross-cutting changes. For UI changes, have it note whether
+  Cypress e2e (`npm run e2e`) is warranted.
+- **security-reviewer**: always when the diff touches auth, the data layer, HTTP/GraphQL
+  surfaces, file uploads, or integration connectors; skip (and say so) only for pure
+  docs/config diffs.
+
+Use their summaries verbatim where possible — do not re-run what they already ran.
+
+## 4. Data-layer & secrets spot-checks
+
+- Confirm no secrets are staged (`git diff --cached --name-only` for `.env`, keys,
+  tokens — the guard blocks writes, but check for files staged by other means).
+- Confirm new persistence code is **Sequelize**, not Prisma
+  (`SEQUELIZE_MIGRATION_GUIDE.md`, `.claude/rules/data-layer.md`).
 
 ## 5. Docs
-- If commands, structure, conventions, or the API surface changed, update the relevant docs
-  (or delegate to the **docs-curator** subagent). Keep `CLAUDE.md` accurate.
+
+- If commands, structure, conventions, or the API surface changed, update the relevant
+  docs or delegate to **docs-curator**. Keep CLAUDE.md and `.claude/rules/` consistent
+  with the change.
 
 ## 6. Report — go / no-go punch list
+
 Return a tight checklist, e.g.:
 - ✅ Quality gate (lint / format / type-check)
-- ✅ Tests: `<scope>` passing
-- ⚠️ Security: <finding + fix>, or "clean"
+- ✅ Tests: `<scope>` passing (per test-runner)
+- ⚠️ Security: <finding + fix>, or "clean" (per security-reviewer)
+- ➖ Skipped: <check> — <why it doesn't apply>
 - ❌ <blocker that must be resolved before PR>
 - 📝 Suggested PR title + 1–3 bullet summary
 
-End with a clear verdict: **ready to open a PR**, or **N items remain**. Do not push or open
-the PR unless the user explicitly asks.
+End with a clear verdict: **ready to open a PR**, or **N items remain**. Do not push or
+open the PR unless the user explicitly asks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,238 +1,183 @@
 # CLAUDE.md — Turbo Asset LLM Operating Guide
 
-Authoritative guidance for Claude (and other AI coding assistants) working in this
-repository. Claude Code loads this file automatically as project memory, so keep it
-**accurate, concise, and high-signal**. Every token here is sent on each request —
-treat it like production config, not a wiki.
+<!-- Maintainers: block-level HTML comments are stripped before this file enters
+     Claude's context, so notes like this one cost zero tokens. Keep this file under
+     ~200 lines (Anthropic's adherence guidance); put area-specific detail in
+     .claude/rules/ and hard guarantees in .claude/settings.json hooks. -->
 
-> **Source of truth for tooling.** This guide follows Anthropic's published practices.
-> When in doubt, defer to the official docs:
-> - Claude Code overview — https://docs.claude.com/en/docs/claude-code/overview
-> - Memory & `CLAUDE.md` — https://docs.claude.com/en/docs/claude-code/memory
-> - Subagents — https://docs.claude.com/en/docs/claude-code/sub-agents
-> - Settings & permissions — https://docs.claude.com/en/docs/claude-code/settings
-> - Slash commands — https://docs.claude.com/en/docs/claude-code/slash-commands
-> - Prompt engineering — https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview
-> - Claude Code best practices — https://www.anthropic.com/engineering/claude-code-best-practices
+Project memory for Claude Code, loaded on **every** request — treat each line like
+production config. Guidance is layered for token efficiency:
 
----
+1. **This file** — always-loaded core facts and rules (kept lean on purpose).
+2. **`.claude/rules/*.md`** — path-scoped conventions (data layer, security, frontend,
+   testing, NAPI packages) that load **only** when you work on matching files.
+3. **Hooks in `.claude/settings.json`** — *enforced* safeguards (`--no-verify`,
+   force-push, `.env`/`.backup` writes, `prisma migrate`). A denied tool call means a
+   guard fired: read the reason and change approach — never try to route around it.
+
+> Tooling source of truth: https://code.claude.com/docs (memory, sub-agents, hooks,
+> settings, skills). Defer to the official docs when in doubt.
 
 ## 1. What this repository is
 
-**Turbo Asset** is an enterprise Integrated Workplace Management System (IWMS) —
-a modern alternative to IBM Tririga for real estate, facilities, asset, lease, and
-workflow management.
+**Turbo Asset** is an enterprise Integrated Workplace Management System (IWMS) — a
+modern IBM Tririga alternative for real estate, facilities, asset, lease, and workflow
+management.
 
 | Aspect | Detail |
 |--------|--------|
 | Language | TypeScript 5.3+ (strict), Node.js ≥ 18 |
 | Backend | Express 4 + Apollo GraphQL (REST + GraphQL) |
 | Database | PostgreSQL via **Sequelize** (migrating off Prisma — see §6) |
-| Real-time | Socket.IO + Redis |
-| Queues | Bull + Redis |
+| Real-time / queues | Socket.IO + Redis · Bull + Redis |
 | Validation | Zod / Joi |
 | Native modules | 42 NAPI-RS workspace packages under `packages/*` |
-| Frontend | Separate Next.js 15 app in `frontend/` (App Router, Tailwind, React 19) |
+| Frontend | Separate Next.js 15 app in `frontend/` (App Router, React 19, Tailwind) |
 | Tests | Jest + Supertest (unit/integration), Cypress (e2e) |
 | Tooling | ESLint + Prettier, Husky + lint-staged, TypeDoc, Swagger |
 
----
-
-## 2. Repository map (where things live)
+## 2. Repository map
 
 ```
 src/                      # Main backend application
-├── api/                  # HTTP surface: controllers, routes, graphql
-│   ├── controllers/
-│   └── routes/
-├── core/                 # Cross-cutting platform: auth, cache, database,
-│                         #   errors, events, middleware, monitoring,
-│                         #   resilience, security, validation
-├── services/             # Domain business logic, grouped by domain
-│                         #   (asset, finance, space, workflow, portfolio…)
-├── shared/               # types / interfaces / constants (import via @/ aliases)
+├── api/                  # controllers/ + routes/ (HTTP surface)
+├── core/                 # Cross-cutting: auth, cache, database, errors, events,
+│                         #   middleware, monitoring, resilience, security, validation
+├── services/             # Domain business logic (asset, finance, space, workflow…)
+├── shared/               # types / interfaces / constants
 ├── graphql/              # Schema + resolvers
-├── config/  constants/  utils/  middleware/  database/
-└── index.ts              # App entry (run with `npm run dev`)
-
-packages/                 # 42 NAPI-RS native service packages (npm workspaces)
-frontend/                 # Next.js 15 web client (own package.json + lint)
+├── config/ constants/ utils/ middleware/ database/
+└── index.ts              # App entry (`npm run dev`)
+packages/                 # 42 NAPI-RS native packages (npm workspaces)
+frontend/                 # Next.js 15 client (own package.json + lint)
 locales/                  # i18n resources (20+ languages)
-prisma/                   # Legacy schema — being phased out (see §6)
+prisma/                   # Legacy schema — being phased out (§6)
 docs/                     # Architecture + per-module API docs (napi-rs/)
-.development/             # Test config, scripts, cypress, validation, dev-only docs
-.claude/                  # Claude Code config: agents/ + skills/ + settings.json
+.development/             # Jest config, scripts, cypress, dev-only docs
+.claude/                  # agents/ + skills/ + rules/ + hooks/ + settings.json
 ```
 
-**Path aliases** (from `tsconfig.json`) — always prefer these over deep relative paths:
+**Path aliases** (`tsconfig.json`) — always prefer over deep relative imports:
+`@/* → src/*`, `@/types|interfaces|constants/* → src/shared/…`, `@/services/*`,
+`@/controllers/* → src/api/controllers/*`, `@/routes/* → src/api/routes/*`,
+`@/middleware|utils|config|database/* → src/core/…`.
 
-```
-@/*            → src/*
-@/types/*      → src/shared/types/*
-@/interfaces/* → src/shared/interfaces/*
-@/constants/*  → src/shared/constants/*
-@/services/*   → src/services/*
-@/controllers/*→ src/api/controllers/*
-@/routes/*     → src/api/routes/*
-@/middleware/* → src/core/middleware/*
-@/utils/*      → src/core/utils/*
-@/config/*     → src/core/config/*
-@/database/*   → src/core/database/*
-```
-
----
-
-## 3. Essential commands
-
-Run from the repo root unless noted. The frontend has its own scripts (`cd frontend`).
+## 3. Essential commands (repo root; frontend has its own)
 
 | Task | Command |
 |------|---------|
-| Dev server (hot reload) | `npm run dev` |
-| Production build | `npm run build` (runs `clean` + `tsc`) |
-| Type-check only | `npm run type-check` |
-| Lint | `npm run lint` · fix: `npm run lint:fix` |
-| Format | `npm run format` · check: `npm run format:check` |
+| Dev server | `npm run dev` |
+| Build | `npm run build` · type-check only: `npm run type-check` |
+| Lint / format | `npm run lint` · `npm run lint:fix` · `npm run format` |
 | **Quality gate (all 3)** | `npm run quality` |
-| Unit/integration tests | `npm test` (Jest, config `.development/jest.config.js`) |
-| Watch tests | `npm run test:watch` |
-| Coverage | `npm run test:coverage` |
-| E2E (Cypress) | `npm run e2e` / `npm run cypress:open` |
-| Build all NAPI packages | `npm run build:napi` |
-| NAPI health check | `npm run napi:health` |
-| Frontend dev | `cd frontend && npm run dev` |
+| Tests | `npm test` · targeted: `npm test -- <path>` · coverage: `npm run test:coverage` |
+| E2E | `npm run e2e` / `npm run cypress:open` |
+| NAPI | `npm run build:napi` · `npm run napi:health` |
+| Frontend | `cd frontend && npm run dev` / `npm run lint` |
 
-**Before declaring work done, run `npm run quality` and the relevant tests.** The
-pre-commit hook (Husky + lint-staged) runs `eslint --fix` + `prettier` on staged
-`*.ts/tsx` and Prettier on `*.json/md`, so don't fight it — let it format.
+**Before declaring work done:** `npm run quality` + the narrowest relevant tests. The
+pre-commit hook (Husky + lint-staged) auto-formats staged files — let it.
 
----
+## 4. Core conventions (always apply)
 
-## 4. Coding conventions
+- **Strict TypeScript** (`strict`, `noUncheckedIndexedAccess`,
+  `exactOptionalPropertyTypes`, `noEmitOnError`): no `any`, no `@ts-ignore`.
+- Controllers thin; business logic in `src/services/*`; cross-cutting in `src/core/*`.
+- Validate at boundaries (Zod/Joi); errors via `src/core/errors`; logging via Winston
+  (`src/core/monitoring`) — never `console.log` in committed code.
+- **No new top-level markdown** unless asked — summaries belong in PR descriptions.
+- Comments only where the *why* is non-obvious.
+- `*.backup` directories are excluded from the build — never edit or import them
+  (hook-enforced).
 
-- **Strict TypeScript.** `tsconfig.json` enables `strict`, `noUncheckedIndexedAccess`,
-  `exactOptionalPropertyTypes`, `noImplicitOverride`, and `noEmitOnError`. Write code
-  that compiles clean — do not paper over types with `any` or `@ts-ignore`.
-- **Imports:** use `@/` path aliases, not `../../../`.
-- **Services are the home for business logic.** Controllers stay thin (parse → validate
-  → delegate → respond). Cross-cutting concerns live in `src/core/*`.
-- **Validation at boundaries** with Zod/Joi; trust internal calls.
-- **Errors:** use the shared error types in `src/core/errors`, not ad-hoc `throw new Error`.
-- **No new top-level docs** unless asked. Summary/analysis markdown belongs in PR
-  descriptions, not the repo root (the root is already crowded — don't add to it).
-- **Comments:** only when the *why* is non-obvious. No "what" narration.
-- **`.backup` directories** (e.g. `src/services/*.backup`) are excluded from the build —
-  never edit them and never import from them.
+Area detail (data layer, security, frontend, testing, packages) loads automatically
+from `.claude/rules/` when you touch matching files — don't re-derive it.
 
----
+## 5. Workflow rules (the ⛔ ones are hook-enforced)
 
-## 5. Workflow rules
-
-- **Branch:** develop on the assigned feature branch; never push to `master` without
-  explicit permission.
-- **Commits:** small, descriptive, present-tense. Don't commit unless asked. Never use
-  `--no-verify` to skip hooks — fix the underlying lint/type error instead.
+- **Branch:** develop on the assigned feature branch; pushing to `master`/`main`
+  prompts for explicit permission. ⛔
+- **Commits:** small, descriptive, present-tense. Don't commit unless asked.
+  `--no-verify` is blocked — fix the underlying error. ⛔
+- **Force-push** is blocked; `rm -rf`, `git reset --hard`, branch deletion prompt for
+  confirmation. ⛔
 - **PRs:** only open one when explicitly requested.
-- **Secrets:** never commit `.env`, keys, or credentials. `.env.example` documents the
-  shape; real values stay local.
-- **Risky/irreversible actions** (deleting branches, force-push, dropping tables,
-  `rm -rf`) require explicit confirmation first.
+- **Secrets:** `.env`/key writes and reads are blocked; `.env.example` documents the
+  shape. ⛔
+- **Irreversible actions** beyond the guards above still require explicit confirmation.
 
----
+## 6. Critical gotcha: Prisma → Sequelize migration
 
-## 6. Critical gotcha: Prisma → Sequelize migration in progress
+The repo is **mid-migration from Prisma to Sequelize**. New persistence code is
+Sequelize / `sequelize-typescript`; `prisma/` and `@prisma/client` are legacy with a
+compatibility adapter; `prisma migrate` is not wired up (hook-blocked). Full rules load
+from `.claude/rules/data-layer.md` when you touch data files; read
+`SEQUELIZE_MIGRATION_GUIDE.md` before any data-layer work. Trust this file and the
+guides over the README, which still mentions Prisma.
 
-The repo is **mid-migration from Prisma to Sequelize**. This matters for almost any
-data-layer task:
+## 7. Token & context efficiency
 
-- **Sequelize is the target.** New persistence code uses Sequelize / `sequelize-typescript`.
-- A **Prisma-compatibility adapter** exists so legacy call sites keep working during the
-  transition — see `SEQUELIZE_MIGRATION_GUIDE.md` and `SEQUELIZE_ADAPTER_ENHANCEMENTS.md`.
-- `npm run db:migrate` is intentionally a no-op pointer; migrations are managed
-  separately per the guide. Don't assume `prisma migrate` is wired up.
-- `prisma/` and `@prisma/client` are **legacy**. The README still references Prisma in
-  places — trust this file and the migration guides over the README for the data layer.
+Context is the scarce resource — spend it deliberately.
 
-When touching the database, read the migration guide first and follow the Sequelize
-path unless explicitly told otherwise.
+**Delegate to keep the main window clean**
+- Open-ended exploration ("where/how is X done?") → **codebase-explorer** agent. Long
+  or noisy test runs → **test-runner**. Security passes on diffs → **security-reviewer**.
+  Subagents burn their own context and return a tight summary.
+- Launch independent subagents **in parallel in one message**; don't redo their work
+  yourself afterward.
 
----
+**Search and read surgically**
+- Known symbol/string → targeted `grep`/`rg`, then read **scoped line ranges**. Never
+  read whole files to find one function; never re-read a file you just edited.
+- Pipe noisy command output through `head`/`tail`/`grep -c` — raw logs never enter
+  the main context.
 
-## 7. Token efficiency — maximize signal, minimize waste
+**Batch and parallelize**
+- Fire independent tool calls in a single message (read 3 files at once; `git status` +
+  `git diff` together). Batch related edits; avoid round-trips.
 
-Context is the scarce resource. Spend it deliberately. (See Anthropic's best-practices
-guide linked above.)
+**Right model for the job**
+- Mechanical search → Haiku-class agents. Implementation → Sonnet. Deep cross-system
+  reasoning → Opus. Match cost to difficulty.
 
-**Searching & reading**
-- For broad/open-ended exploration ("where is X handled across the codebase?"), delegate
-  to the **`codebase-explorer`** subagent (§8). It burns its own context and returns a
-  tight summary, keeping your main window clean.
-- For a known symbol or string, use a **targeted `grep`/`rg`** — don't read whole files
-  to find one function.
-- Read **scoped line ranges**, not entire files, once you know the location.
-- Never re-read a file you just edited — the edit already confirmed its new state.
-- Don't dump large command output into context. Pipe through `head`, `grep`, or `wc`.
-
-**Parallelism & batching**
-- Fire independent tool calls **in a single message** (parallel) — e.g. read three files
-  at once, or run `git status` + `git diff` together.
-- Batch related edits; avoid round-trips.
-
-**Right tool / right model**
-- Cheap, mechanical search → Haiku-class subagents. Implementation → Sonnet.
-  Deep cross-system reasoning → Opus. Match cost to difficulty.
-- Lean on subagents to **parallelize independent work** and to **firewall noisy output**
-  (test logs, large greps) away from the main thread.
+**Durability across compaction**
+- Long sessions get compacted; conversation content can drop, while this file is
+  re-injected. Decisions that must survive (conventions, commands, gotchas) belong in
+  CLAUDE.md or `.claude/rules/` — propose the edit instead of repeating yourself.
 
 **Don't waste effort**
-- No speculative refactors, abstractions, or "while I'm here" cleanups beyond the task.
-- Re-use prior findings instead of re-deriving them.
+- No speculative refactors or "while I'm here" cleanups. Re-use prior findings instead
+  of re-deriving them.
 
----
+## 8. Delegation roster (`.claude/agents/`, `.claude/skills/`)
 
-## 8. Subagent roster (`.claude/agents/`)
-
-Use the right specialist instead of doing everything inline. Each lives in
-`.claude/agents/` with a scoped tool set. Invoke proactively when the task matches.
+Use the matching specialist proactively instead of doing everything inline. Each agent
+has a scoped toolset, model, and turn budget; explorer and security-reviewer keep
+persistent memory across sessions, so their recall improves over time.
 
 | Agent | Use it for |
 |-------|-----------|
-| **codebase-explorer** | Read-only search/navigation across `src/` and `packages/`. First stop for "where / how is X done?" Returns a concise map, not raw dumps. |
-| **service-architect** | Designing or scaffolding a new domain service or NAPI package that follows the controller→service→core layering and path-alias conventions. |
-| **test-runner** | Running Jest/Cypress, triaging failures, and reporting a fix-list. Keeps verbose test output out of the main context. |
-| **security-reviewer** | Reviewing a diff for OWASP issues, secret leakage, authZ gaps, and injection risks before commit. |
-| **docs-curator** | Keeping `CLAUDE.md`, `docs/`, and module docs accurate after code changes; flags drift. |
-
-To add or edit agents, follow https://docs.claude.com/en/docs/claude-code/sub-agents
-(markdown + YAML frontmatter: `name`, `description`, optional `tools`/`model`).
-
-### Skills (`.claude/skills/`)
-
-Skills are repeatable **workflows** Claude runs in the main thread (invoke with
-`/<skill-name>`), as opposed to agents, which are delegated workers. See
-https://docs.claude.com/en/docs/claude-code/skills.
+| **codebase-explorer** (Haiku) | Read-only search/navigation. First stop for "where/how is X done?" |
+| **service-architect** (Sonnet) | Scaffolding services/packages that follow the layering + aliases. |
+| **test-runner** (Sonnet) | Running Jest/Cypress, triaging failures; keeps logs out of main context. |
+| **security-reviewer** (Sonnet) | OWASP/tenancy/secrets review of a diff before commit. |
+| **docs-curator** (Sonnet) | Keeping CLAUDE.md, rules, and docs/ accurate after changes. |
 
 | Skill | Use it for |
 |-------|-----------|
-| **pr-readiness** | Pre-PR gate: runs the quality gate + relevant tests, pulls in the security-reviewer and docs-curator agents, and returns a go/no-go punch list. Run it before opening any PR. |
+| **/pr-readiness** | Pre-PR gate: quality gate + tests + parallel security/docs passes → go/no-go punch list. Run before any PR. |
 
----
+To add or edit agents/skills, follow https://code.claude.com/docs/en/sub-agents
+(frontmatter: `name`, `description`, plus `tools`, `model`, `maxTurns`, `memory`).
 
-## 9. Security & enterprise expectations
+## 9. Security baseline
 
-- Treat all external input (HTTP, GraphQL, file upload, integration payloads) as
-  untrusted. Validate and sanitize at the edge.
-- Enforce authZ in services, not just routes; respect `organizationId` tenancy on
-  `BaseEntity` records.
-- Use parameterized queries / ORM methods — never string-concatenate SQL.
-- Keep dependencies current; flag, don't silently downgrade, packages.
-- Log via Winston (`src/core/monitoring`), never `console.log` in committed code.
-- This is multi-tenant enterprise software — assume every record is scoped to an org and
-  every action is audited (`src/core/audit`).
+Multi-tenant enterprise software: every record is org-scoped (`organizationId` on
+`BaseEntity`), every action audited (`src/core/audit`). External input is untrusted —
+validate at the edge; enforce authZ in services, not just routes; parameterized queries
+only. Full requirements load from `.claude/rules/security.md` on matching files.
 
----
+## 10. When unsure
 
-## 10. When you're unsure
-
-Ask a focused question rather than guessing on anything ambiguous, irreversible, or
+Ask one focused question rather than guessing on anything ambiguous, irreversible, or
 architecturally significant. A 10-second clarification beats a wrong 10-minute build.


### PR DESCRIPTION
Restructure AI-assistant guidance into three layers per current Claude Code
practice (memory is advisory; hooks enforce):

- CLAUDE.md: trim 238 -> 183 lines (under the documented ~200-line adherence
  target); keep always-needed core, move area detail out
- .claude/rules/: new path-scoped rules (backend, data-layer, security,
  frontend, testing, napi-packages) that load only when matching files are
  touched, cutting per-session context cost
- .claude/hooks/guard.cjs + settings.json PreToolUse hooks: enforce the
  previously advisory rules — deny hook-skipping commits, force-push,
  env/backup/generated-path writes, prisma migrate; ask-first on rm -rf,
  push to master/main, destructive git ops
- settings.json: broader read-only allowlist; deny reads of env files and
  key material
- Agents: add maxTurns budgets, persistent memory (codebase-explorer,
  security-reviewer), colors, parallel-search and output-budget guidance
- pr-readiness skill: run test-runner and security-reviewer concurrently,
  add secrets/data-layer spot-checks and explicit skip reporting

https://claude.ai/code/session_018vyvnfv6mnJnmJ2FncLksK

## Summary by Sourcery

Restructure Claude Code configuration into a lean core guide, path-scoped rules, and enforced hooks to improve token efficiency and safeguard critical workflows.

Enhancements:
- Streamline CLAUDE.md into an always-loaded core guide and introduce separate path-scoped rules files for backend, data-layer, security, frontend, testing, and NAPI packages that load only when relevant.
- Tighten and enrich agent and skill definitions with turn budgets, colors, persistent memory, and clearer guidance on delegation, parallelism, and context hygiene.
- Add detailed, scoped conventions for backend architecture, data-layer migration, testing, frontend, NAPI packages, and security that are automatically applied based on touched paths.

Build:
- Introduce a PreToolUse guard hook script and associated settings to block or require confirmation for risky git, filesystem, and Prisma migration commands, and to prevent writes to env, backup, and generated paths.

Documentation:
- Update CLAUDE.md and docs-curator guidance to reflect Claude Code’s current three-layer config model, token limits, and authoritative documentation sources.

Tests:
- Refine the pr-readiness skill and test-runner agent to run quality and security checks in parallel, emphasize narrow test scopes, and improve reporting of skipped checks, flaky behavior, and executed commands.